### PR TITLE
[pt]keys stats fail if any windows have no keystrokes.

### DIFF
--- a/selfstats.py
+++ b/selfstats.py
@@ -358,17 +358,17 @@ class Selfstats:
         if self.args['pkeys']:
             print 'Processes sorted by keystrokes:'
             pdata = self.processes.items()
-            pdata.sort(key=lambda x:x[1]['keystrokes'], reverse=True)
+            pdata.sort(key=lambda x:x[1].get('keystrokes',0), reverse=True)
             for name, data in pdata:
-                print name, data['keystrokes']
+                print name, data.get('keystrokes',0)
             print
 
         if self.args['tkeys']:
             print 'Window titles sorted by keystrokes:'
             wdata = self.windows.items()
-            wdata.sort(key=lambda x:x[1]['keystrokes'], reverse=True)
+            wdata.sort(key=lambda x:x[1].get('keystrokes',0), reverse=True)
             for name, data in wdata:
-                print name, data['keystrokes']
+                print name, data.get('keystrokes',0)
             print
 
         if self.args['pactive']:


### PR DESCRIPTION
As stated above, if a window has never been typed in, the `'keystrokes'` key doesn't exist in its process dictionary and so the sorting and printing (both of which used a straight `['keystrokes']` lookup) gives the following error:

```
$ ./selfstats.py --pkeys
9755 keystrokes in 1116 key sequences, 18972 clicks (5227 excluding scroll), 638426 mouse movements

Processes sorted by keystrokes:
Traceback (most recent call last):
  File "./selfstats.py", line 499, in <module>
    ss.do()
  File "./selfstats.py", line 156, in do
    self.show_summary()
  File "./selfstats.py", line 361, in show_summary
    pdata.sort(key=lambda x:x[1]['keystrokes'], reverse=True)
  File "./selfstats.py", line 361, in <lambda>
    pdata.sort(key=lambda x:x[1]['keystrokes'], reverse=True)
KeyError: 'keystrokes'
```

(And similarly for `--tkeys`.)

This is the only place this occurs--everywhere else uses a `.get('keystrokes', 0)` call--so presumably the direct lookup is just a typo.
