### PR TITLE
Update pyobjc requirements

### DIFF
--- a/osx-requirements.txt
+++ b/osx-requirements.txt
@@ -2,4 +2,7 @@ SQLAlchemy==0.7.6
 lockfile==0.9.1
 pycrypto==2.5
 python-daemon==1.6
-pyobjc==2.3
+pyobjc=2.4
+pyobjc-framework-Cocoa==2.4
+pyobjc-framework-Quartz==2.4
+pyobjc-framework-CoreData==2.4


### PR DESCRIPTION
pyobjc now seems to work from pypi. See #31, ljos#3 .
