### PR TITLE
Add support for keyring password storage

### DIFF
--- a/osx-requirements.txt
+++ b/osx-requirements.txt
@@ -4,4 +4,5 @@ pycrypto==2.5
 python-daemon==1.6
 pyobjc-core==2.4
 pyobjc==2.4
+keyring==1.2.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ lockfile==0.9.1
 pycrypto==2.5
 python-daemon==1.6
 svn+https://python-xlib.svn.sourceforge.net/svnroot/python-xlib/tags/xlib_0_15rc1/
+keyring==1.2.2
 

--- a/selfspy/password_dialog.py
+++ b/selfspy/password_dialog.py
@@ -19,39 +19,141 @@ import sys
 import getpass
 
 from Tkinter import Tk
-import tkSimpleDialog
+from tkSimpleDialog import Dialog
+
 
 def get_password(verify=None, message=None):
-    if sys.stdin.isatty():
-        for i in xrange(3):
-            if message:
-                pw = getpass.getpass(message)
-            else:
-                pw = getpass.getpass()
-            if (not verify) or verify(pw):
-                break
+    if (not verify):
+        pw = get_user_password(verify, message)
     else:
-        pw = get_tk_password(verify, message)
+        pw = get_keyring_password(verify)
+
+    if pw == None:
+        pw = get_user_password(verify, message)
+
     return pw
 
-def get_tk_password(verify, message=None):
+
+def get_user_password(verify, message=None, force_save=False):
+    if sys.stdin.isatty():
+        pw = get_tty_password(verify, message, force_save)
+    else:
+        pw = get_tk_password(verify, message, force_save)
+
+    return pw
+
+
+def get_keyring_password(verify, message=None):
+    pw = None
+    try:
+        import keyring
+
+        usr = getpass.getuser()
+        pw = keyring.get_password('Selfspy', usr)
+
+        if pw is not None:
+            if (not verify) or not verify(pw):
+                print 'The keyring password is not valid. Please, input the correct one.'
+                pw = get_user_password(verify, message, force_save=True)
+    except ImportError:
+        print 'keyring library not found'
+
+    return pw
+
+
+def set_keyring_password(password):
+    try:
+        import keyring
+        usr = getpass.getuser()
+        keyring.set_password('Selfspy', usr, password)
+    except ImportError:
+        print 'Unable to save password to keyring (library not found)'
+    except NameError:
+        pass
+    except:
+        print 'Unable to save password to keyring'
+
+
+def get_tty_password(verify, message=None, force_save=False):
+    verified = False
+    for i in xrange(3):
+        if message:
+            pw = getpass.getpass(message)
+        else:
+            pw = getpass.getpass()
+        if (not verify) or verify(pw):
+            verified = True
+            break
+
+    if not verified:
+        print 'Password failed'
+        sys.exit(1)
+
+    if not force_save:
+        while True:
+            store = raw_input("Do you want to store the password in the keychain [Y/N]: ")
+            if store.lower() in ['n', 'y']:
+                break
+        save_to_keychain = store.lower() == 'y'
+    else:
+        save_to_keychain = True
+
+    if save_to_keychain:
+        set_keyring_password(pw)
+
+    return pw
+
+
+def get_tk_password(verify, message=None, force_save=False):
     root = Tk()
     root.withdraw()
     if message is None:
         message = 'Password'
 
     while True:
-        pw = tkSimpleDialog.askstring(title='Selfspy encryption password',
-                                      prompt=message,
-                                      show='*',
-                                      parent=root)
-
+        pw, save_to_keychain = PasswordDialog(title='Selfspy encryption password',
+                            prompt=message,
+                            parent=root)
         if pw is None:
             return ""
 
         if (not verify) or verify(pw):
             break
+
+    if save_to_keychain or force_save:
+        set_keyring_password(pw)
+
     return pw
+
+
+class PasswordDialog(Dialog):
+
+    def __init__(self, title, prompt, parent):
+        self.prompt = prompt
+        Dialog.__init__(self, parent, title)
+
+    def body(self, master):
+        from Tkinter import Label
+        from Tkinter import Entry
+        from Tkinter import Checkbutton
+        from Tkinter import IntVar
+        from Tkinter import W
+
+        self.checkVar = IntVar()
+
+        Label(master, text=self.prompt).grid(row=0, sticky=W)
+
+        self.e1 = Entry(master)
+
+        self.e1.grid(row=0, column=1)
+
+        self.cb = Checkbutton(master, text="Save to keychain", variable=self.checkVar)
+        self.cb.pack()
+        self.cb.grid(row=1, columnspan=2, sticky=W)
+        self.configure(show='*')
+
+    def apply(self):
+        self.result = (self.e1.get(), self.checkVar.get() == 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have added support for keyring based password storage and tested it on OSX.

It uses the [keyring library](https://pypi.python.org/pypi/keyring) so it should work with OSX, KDE, Gnome and Windows 2k+.
