### PR TITLE
Add plist for automatic start at login on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Unless you use the --no-text flag, selfspy will store everything you type in two
 
 Normally you would like Selfspy to start automatically when you launch X. How to do this depends on your system, but it will normally mean editing *~/.xinitrc* or *~/.xsession*. If you run KDE, *~/.kde/Autostart*, is a good place to put startup scripts. When run, Selfspy will immediately spawn a daemon and exit.
 
+#### Running on login in OS X
+If you want selfspy to start automatically on login you need to copy the [com.github.gurgeh.selfspy.plist](https://github.com/gurgeh/selfspy/raw/master/com.github.gurgeh.selfspy.plist)
+file to `~/Library/LaunchAgents/` or run
+```
+curl https://github.com/gurgeh/selfspy/raw/master/com.github.gurgeh.selfspy.plist > ~/Library/LaunchAgents/com.github.selfspy.plist
+```
+
 ### Example Statistics
 *"OK, so now all this data will be stored, but what can I use it for?"*
 

--- a/com.github.gurgeh.selfspy.plist
+++ b/com.github.gurgeh.selfspy.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.github.gurgeh.selfspy</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/python</string>
+      <string>/usr/local/share/python/selfspy</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
Now you can close #47 .

I think eventually it should be some option to turn this on when building, but right now it is good enough as it is. Especially since we have some problems with selfspy being a bit resource intensive.
