### PR TITLE
Add forgotten configuration when installing on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ https://github.com/gurgeh/selfspy/issues
 General discussion here:
 http://ost.io/gurgeh/selfspy
 
+#### OS X
+In OS X you also need to enable access for assistive devices.
+To do that there is a checkbox in `System Preferences > Accessibility`.
 
 ### Running Selfspy
 You run selfspy with `selfspy`. You should probably start with `selfspy --help` to get to know the command line arguments. As of this writing, it should look like this:


### PR DESCRIPTION
If the user does not enable access for assistive devices we do not get access the event callback will not fire correctly.
