### PR TITLE
Fixes the strange '<' rendering issue on github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ http://ost.io/gurgeh/selfspy
 
 #### OS X
 In OS X you also need to enable access for assistive devices.
-To do that in <10.9 there is a checkbox in `System Preferences > Accessibility`,
+To do that in &lt;10.9 there is a checkbox in `System Preferences > Accessibility`,
 in 10.9 you have to add the correct application in
 `System Preferences > Privacy > Accessability`.
 


### PR DESCRIPTION
This fixes the strange 'lesser than' rendering issue of the README here on github.

![screenshot 2014-02-24 00 15 52](https://f.cloud.github.com/assets/219704/2241739/82ac49ac-9ce0-11e3-8ebc-fbfeffbceb7d.png)

![screenshot 2014-02-24 00 16 49](https://f.cloud.github.com/assets/219704/2241741/98bb8758-9ce0-11e3-8e53-0a805a8d7806.png)

Signed-off-by: Markus Hubig mhubig@gmail.com
