### PR TITLE
selfspy option to not record special keypresses as repeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ optional arguments:
                         letters. Key timings are stored to enable activity
                         calculation in selfstats. If this switch is used,
                         you will never be asked for password.
+  -r, --no-repeat       Do not store special characters as repeated
+                        characters.
   --change-password     Change the password used to encrypt the keys columns
                         and exit.
 ```

--- a/selfspy/__init__.py
+++ b/selfspy/__init__.py
@@ -53,7 +53,8 @@ def parse_config():
     parser.add_argument('-d', '--data-dir', help='Data directory for selfspy, where the database is stored. Remember that Selfspy must have read/write access. Default is %s' % cfg.DATA_DIR, default=cfg.DATA_DIR)
 
     parser.add_argument('-n', '--no-text', action='store_true', help='Do not store what you type. This will make your database smaller and less sensitive to security breaches. Process name, window titles, window geometry, mouse clicks, number of keys pressed and key timings will still be stored, but not the actual letters. Key timings are stored to enable activity calculation in selfstats. If this switch is used, you will never be asked for password.')
-
+    parser.add_argument('-r', '--no-repeat', action='store_true', help='Do not store special characters as repeated characters.')
+    
     parser.add_argument('--change-password', action="store_true", help='Change the password used to encrypt the keys columns and exit.')
 
     return parser.parse_args()
@@ -107,7 +108,8 @@ def main():
         print 'Re-encrypting your keys...'
         astore = ActivityStore(os.path.join(args['data_dir'], cfg.DBNAME),
                                encrypter,
-                               store_text=(not args['no_text']))
+                               store_text=(not args['no_text']),
+                               repeat_char=(not args['no_repeat']))
         astore.change_password(new_encrypter)
         # delete the old password.digest
         os.remove(os.path.join(args['data_dir'], check_password.DIGEST_NAME))
@@ -118,7 +120,8 @@ def main():
 
     astore = ActivityStore(os.path.join(args['data_dir'], cfg.DBNAME),
                            encrypter,
-                           store_text=(not args['no_text']))
+                           store_text=(not args['no_text']),
+                           repeat_char=(not args['no_repeat']))
     cfg.LOCK.acquire()
     try:
         astore.run()

--- a/selfspy/activity_store.py
+++ b/selfspy/activity_store.py
@@ -54,12 +54,13 @@ class KeyPress:
 
 
 class ActivityStore:
-    def __init__(self, db_name, encrypter=None, store_text=True):
+    def __init__(self, db_name, encrypter=None, store_text=True, repeat_char=True):
         self.session_maker = models.initialize(db_name)
 
         models.ENCRYPTER = encrypter
 
         self.store_text = store_text
+        self.repeat_char = repeat_char
         self.curtext = u""
 
         self.key_presses = []
@@ -160,7 +161,8 @@ class ActivityStore:
 
     def store_keys(self):
         """ Stores the current queued key-presses """
-        self.filter_many()
+        if self.repeat_char:
+            self.filter_many()
 
         if self.key_presses:
             keys = [press.key for press in self.key_presses]


### PR DESCRIPTION
using the `-r | --no-repeat` option forces individual recording of
special characters. Special characters have been recorded with a count
integer <[Backspace]x2>. When using `-r | --no-repeat` the same 2
characters will be recorded as <[Backspace]><[Backspace]>.
