### PR TITLE
selfspy option to report spaces as <[Space]>

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ optional arguments:
                         letters. Key timings are stored to enable activity
                         calculation in selfstats. If this switch is used,
                         you will never be asked for password.
+  -s, --report-space    Report space as <[Space]>.
   --change-password     Change the password used to encrypt the keys columns
                         and exit.
 ```

--- a/selfspy/__init__.py
+++ b/selfspy/__init__.py
@@ -53,6 +53,7 @@ def parse_config():
     parser.add_argument('-d', '--data-dir', help='Data directory for selfspy, where the database is stored. Remember that Selfspy must have read/write access. Default is %s' % cfg.DATA_DIR, default=cfg.DATA_DIR)
 
     parser.add_argument('-n', '--no-text', action='store_true', help='Do not store what you type. This will make your database smaller and less sensitive to security breaches. Process name, window titles, window geometry, mouse clicks, number of keys pressed and key timings will still be stored, but not the actual letters. Key timings are stored to enable activity calculation in selfstats. If this switch is used, you will never be asked for password.')
+    parser.add_argument('-s', '--report-space', action='store_true', help='Report space as <[Space]>.')
 
     parser.add_argument('--change-password', action="store_true", help='Change the password used to encrypt the keys columns and exit.')
 
@@ -107,7 +108,8 @@ def main():
         print 'Re-encrypting your keys...'
         astore = ActivityStore(os.path.join(args['data_dir'], cfg.DBNAME),
                                encrypter,
-                               store_text=(not args['no_text']))
+                               store_text=(not args['no_text']),
+                               report_space=args['report_space'])
         astore.change_password(new_encrypter)
         # delete the old password.digest
         os.remove(os.path.join(args['data_dir'], check_password.DIGEST_NAME))
@@ -118,7 +120,8 @@ def main():
 
     astore = ActivityStore(os.path.join(args['data_dir'], cfg.DBNAME),
                            encrypter,
-                           store_text=(not args['no_text']))
+                           store_text=(not args['no_text']),
+                           report_space=args['report_space'])
     cfg.LOCK.acquire()
     try:
         astore.run()

--- a/selfspy/activity_store.py
+++ b/selfspy/activity_store.py
@@ -54,12 +54,13 @@ class KeyPress:
 
 
 class ActivityStore:
-    def __init__(self, db_name, encrypter=None, store_text=True):
+    def __init__(self, db_name, encrypter=None, store_text=True, report_space=True):
         self.session_maker = models.initialize(db_name)
 
         models.ENCRYPTER = encrypter
 
         self.store_text = store_text
+        self.report_space = report_space
         self.curtext = u""
 
         self.key_presses = []
@@ -93,6 +94,7 @@ class ActivityStore:
         self.sniffer.key_hook = self.got_key
         self.sniffer.mouse_button_hook = self.got_mouse_click
         self.sniffer.mouse_move_hook = self.got_mouse_move
+        self.sniffer.report_space = self.report_space
 
         self.sniffer.run()
 

--- a/selfspy/sniff_cocoa.py
+++ b/selfspy/sniff_cocoa.py
@@ -37,6 +37,7 @@ class Sniffer:
         self.mouse_button_hook = lambda x: True
         self.mouse_move_hook = lambda x: True
         self.screen_hook = lambda x: True
+        self.report_space = lambda x: False
 
     def createAppDelegate(self):
         sc = self
@@ -141,6 +142,8 @@ class Sniffer:
                     character = "Enter"
                 elif event.keyCode() is 51:
                     character = "Backspace"
+                elif ((event.keyCode() is 49) and self.report_space):
+                    character = "Space"
                 self.key_hook(event.keyCode(),
                               modifiers,
                               keycodes.get(character,


### PR DESCRIPTION
this provides the option -s to change reported spaces (' ') as <[Space]>
This commit only updates sniff_cocoa...since I only have a mac. I'd love
some help providing similar funtionality for the win and x sniff files.
