### PR TITLE
fix dates parse

### DIFF
--- a/selfspy/stats.py
+++ b/selfspy/stats.py
@@ -93,17 +93,17 @@ def make_time_string(dates, clock):
     if dates is None:
         dates = []
 
-    if isinstance(dates, list) and len(dates)>0:
+    if isinstance(dates, list) and len(dates) > 0:
         if type(dates[0]) is str:
             datesstr = " ".join(dates)
         else:
-            print '%s is of uncompatible type list of %s.' % (who, str(type(dates[0])))
+            print '%s is of uncompatible type list of %s.' % (
+                dates[0], str(type(dates[0])))
     elif isinstance(dates, basestring):
-        datesstr = dates.split() # any whitespace
+        datesstr = dates
     else:
-        print '%s is of uncompatible type %s.' % (who, str(type(dates)))
-        sys.exit(1)
-    dates = datesstr
+        datesstr = now.strftime('%Y %m %d')
+    dates = datesstr.split()  # any whitespace
 
     if len(dates) > 3:
         print 'Max three arguments to date', dates


### PR DESCRIPTION
When I run the `selfstats -P chrome --clock 00:00 --tactive` I got error:

```
Traceback (most recent call last):
  File "/usr/local/bin/selfstats", line 9, in <module>
    load_entry_point('selfspy==0.3.0', 'console_scripts', 'selfstats')()
  File "build/bdist.macosx-10.9-x86_64/egg/selfspy/stats.py", line 590, in main
  File "build/bdist.macosx-10.9-x86_64/egg/selfspy/stats.py", line 205, in do
  File "build/bdist.macosx-10.9-x86_64/egg/selfspy/stats.py", line 367, in calc_summary
  File "build/bdist.macosx-10.9-x86_64/egg/selfspy/stats.py", line 289, in filter_keys
  File "build/bdist.macosx-10.9-x86_64/egg/selfspy/stats.py", line 265, in filter_prop
  File "build/bdist.macosx-10.9-x86_64/egg/selfspy/stats.py", line 104, in make_time_string
NameError: global name 'who' is not defined
```

or run `selfstats --date 2014 12 23 --limit 1 d -P vim --tkeys` I got:

```
Max three arguments to date 2014 12 23
```

This pull request fix these bugs.