### PR TITLE
updated pyobjc versions for Yosemite

### DIFF
--- a/osx-requirements.txt
+++ b/osx-requirements.txt
@@ -1,7 +1,7 @@
 SQLAlchemy==0.9.4
 lockfile==0.9.1
 pycrypto==2.5
-pyobjc-core==3.0.1
-pyobjc-framework-Cocoa==3.0.1
+pyobjc-core==3.0.4
+pyobjc-framework-Cocoa==3.0.4
 keyring==1.2.2
-pyobjc-framework-Quartz==3.0.1
+pyobjc-framework-Quartz==3.0.4


### PR DESCRIPTION
Old versions of pyobjc-core,  pyobjc-framework-Cocoa, and pyobjc-framework-Quartz were causing selfspy installation to error out on OSX 10.10