### PR TITLE
Updated OSX requirements with newer pyobjc dependencies (3.0.4). 

### DIFF
--- a/com.github.gurgeh.selfspy.plist
+++ b/com.github.gurgeh.selfspy.plist
@@ -7,8 +7,7 @@
     <string>com.github.gurgeh.selfspy</string>
     <key>ProgramArguments</key>
     <array>
-      <string>/usr/local/bin/python</string>
-      <string>/usr/local/share/python/selfspy</string>
+      <string>/usr/local/bin/selfspy</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/osx-requirements.txt
+++ b/osx-requirements.txt
@@ -1,7 +1,7 @@
 SQLAlchemy==0.9.4
 lockfile==0.9.1
 pycrypto==2.5
-pyobjc-core==3.0.1
-pyobjc-framework-Cocoa==3.0.1
+pyobjc-core==3.0.4
+pyobjc-framework-Cocoa==3.0.4
 keyring==1.2.2
-pyobjc-framework-Quartz==3.0.1
+pyobjc-framework-Quartz==3.0.4


### PR DESCRIPTION
This fixes installation issues on OSX Yosemite. Issue: https://github.com/gurgeh/selfspy/issues/118 