### PR TITLE
Fix for Issue #56, Google Chrome Window Titles

### DIFF
--- a/osx-requirements.txt
+++ b/osx-requirements.txt
@@ -1,7 +1,8 @@
 SQLAlchemy==0.9.4
 lockfile==0.9.1
 pycrypto==2.5
-pyobjc-core==3.0.1
-pyobjc-framework-Cocoa==3.0.1
+pyobjc-core==3.0.4
+pyobjc-framework-Cocoa==3.0.4
 keyring==1.2.2
-pyobjc-framework-Quartz==3.0.1
+pyobjc-framework-Quartz==3.0.4
+pyobjc-framework-ScriptingBridge==3.0.4

--- a/selfspy/sniff_cocoa.py
+++ b/selfspy/sniff_cocoa.py
@@ -34,6 +34,10 @@ from Quartz import (
     kCGWindowListOptionOnScreenOnly,
     kCGNullWindowID
 )
+
+from Foundation import *
+from ScriptingBridge import *
+
 from PyObjCTools import AppHelper
 import config as cfg
 
@@ -109,12 +113,22 @@ class Sniffer:
                             or (not event.windowNumber()
                                 and window['kCGWindowOwnerName'] == app.localizedName())):
                             geometry = window['kCGWindowBounds']
-                            self.screen_hook(window['kCGWindowOwnerName'],
-                                             window.get('kCGWindowName', u''),
-                                             geometry['X'],
-                                             geometry['Y'],
-                                             geometry['Width'],
-                                             geometry['Height'])
+                            if app.localizedName() == "Google Chrome":
+                                chrome = SBApplication.applicationWithBundleIdentifier_("com.google.Chrome")
+                                self.screen_hook(window['kCGWindowOwnerName'],
+                                                 chrome.windows()[0].activeTab().title(),
+                                                 geometry['X'],
+                                                 geometry['Y'],
+                                                 geometry['Width'],
+                                                 geometry['Height'])
+                            else:
+                                self.screen_hook(window['kCGWindowOwnerName'],
+                                                 window.get('kCGWindowName', u''),
+                                                 geometry['X'],
+                                                 geometry['Y'],
+                                                 geometry['Width'],
+                                                 geometry['Height'])
+
                             break
                     break
 


### PR DESCRIPTION
Pull request that updates PyObjC to 3.0.4 (looks like an open request to do that already exists) and adds an if/else clause to use the Scripting Bridge code to get Chrome frontmost tab title in place of window title. Working for me. 