### PR TITLE
Remove int type check on 'limit' parameter value

### DIFF
--- a/selfspy/stats.py
+++ b/selfspy/stats.py
@@ -570,13 +570,6 @@ def main():
 
     ss = Selfstats(os.path.join(args['data_dir'], cfg.DBNAME), args)
 
-    if args['limit']:
-        try:
-            int(args['limit'][0])
-        except ValueError:
-            print 'First argument to --limit must be an integer'
-            sys.exit(1)
-
     if ss.need_text or ss.need_keys:
         if args['password'] is None:
             args['password'] = get_password(verify=check_with_encrypter)


### PR DESCRIPTION
87bf8d327e512fb3ed5cef4720f7354b3fe81943 allows "2h" as values so the
int check no longer applies. In addition only limit was checked so I
strongly suspect this is an historical check.

Ie. the check prevents

    selfstats --limit 2h

from working