### PR TITLE
Fix regressions in 'make_time_string'

### DIFF
--- a/selfspy/stats.py
+++ b/selfspy/stats.py
@@ -93,17 +93,9 @@ def make_time_string(dates, clock):
     if dates is None:
         dates = []
 
-    if isinstance(dates, list) and len(dates)>0:
-        if type(dates[0]) is str:
-            datesstr = " ".join(dates)
-        else:
-            print '%s is of uncompatible type list of %s.' % (who, str(type(dates[0])))
-    elif isinstance(dates, basestring):
-        datesstr = dates.split() # any whitespace
-    else:
-        print '%s is of uncompatible type %s.' % (who, str(type(dates)))
-        sys.exit(1)
-    dates = datesstr
+    # Values origination from the config file are not splitted
+    if isinstance(dates, basestring):
+        dates = dates.split() # any whitespace
 
     if len(dates) > 3:
         print 'Max three arguments to date', dates


### PR DESCRIPTION
Seems to been introduced in https://github.com/gurgeh/selfspy/pull/111
Commit 769fd6c37e2a67aadd1ada8dfd8358068458349d

Symptom:

```
selfstats --clock "11:20" --limit 1 h
<RowID> <Starting date and time> <Duration> <Process> <Window title> <Number of keys pressed>
Traceback (most recent call last):
  File "/usr/bin/selfstats", line 9, in <module>
    load_entry_point('selfspy==0.3.0', 'console_scripts', 'selfstats')()
  File "build/bdist.linux-x86_64/egg/selfspy/stats.py", line 590, in main
  File "build/bdist.linux-x86_64/egg/selfspy/stats.py", line 208, in do
  File "build/bdist.linux-x86_64/egg/selfspy/stats.py", line 333, in show_rows
  File "build/bdist.linux-x86_64/egg/selfspy/stats.py", line 289, in filter_keys
  File "build/bdist.linux-x86_64/egg/selfspy/stats.py", line 265, in filter_prop
  File "build/bdist.linux-x86_64/egg/selfspy/stats.py", line 104, in make_time_string
NameError: global name 'who' is not defined
```

The following behavior is obivously a bug: (in addition to the undefined 'who')

```
make_time_string(None, "11:20")
--> Fail
make_time_string(["10" "3"], "11:20")
--> Fail
```

Looking at the code we find some weird(?) behavior:

```
if isinstance(dates, list) and len(dates)>0:
    if type(dates[0]) is str:
        datesstr = " ".join(dates)
    else:
        print '%s is of uncompatible type list of %s.' % (who, str(type(dates[0])))
elif isinstance(dates, basestring):
    datesstr = dates.split() # any whitespace
else:
    print '%s is of uncompatible type %s.' % (who, str(type(dates))) # line 104
    sys.exit(1)
dates = datesstr

if len(dates) > 3:
```

After this code block 'dates' are sometimes a string and sometimes a list.
The subsequent code seems to assume that 'dates' are a list.

Ie. what is this block supposed to do?

```
if isinstance(dates, list) and len(dates)>0:
    if type(dates[0]) is str:
        datesstr = " ".join(dates)
    else:
        print '%s is of uncompatible type list of %s.' % (who, str(type(dates[0])))
```

If I understand pull request 111 correctly we need to support 'dates' as a
white space separated string since the config values are not "shell expanded"

Simply removng the block above works as far I can see. (tested with a
simple config file)
