### PR TITLE
OSX: Performance improvement and "ignoring" layered windows

### DIFF
--- a/com.github.gurgeh.selfspy.plist
+++ b/com.github.gurgeh.selfspy.plist
@@ -7,8 +7,7 @@
     <string>com.github.gurgeh.selfspy</string>
     <key>ProgramArguments</key>
     <array>
-      <string>/usr/local/bin/python</string>
-      <string>/usr/local/share/python/selfspy</string>
+      <string>/usr/local/bin/selfspy</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/osx-requirements.txt
+++ b/osx-requirements.txt
@@ -1,7 +1,7 @@
 SQLAlchemy==0.9.4
 lockfile==0.9.1
 pycrypto==2.5
-pyobjc-core==3.0.1
-pyobjc-framework-Cocoa==3.0.1
+pyobjc-core==3.0.4
+pyobjc-framework-Cocoa==3.0.4
 keyring==1.2.2
-pyobjc-framework-Quartz==3.0.1
+pyobjc-framework-Quartz==3.0.4

--- a/selfspy/activity_store.py
+++ b/selfspy/activity_store.py
@@ -74,6 +74,7 @@ class ActivityStore:
         self.last_commit = time.time()
 
         self.started = NOW()
+        self.last_screen_change = None
 
     def trycommit(self):
         self.last_commit = time.time()
@@ -107,6 +108,13 @@ class ActivityStore:
         win_y -- the y position of the window
         win_width -- the width of the window
         win_height -- the height of the window"""
+
+        # skip the event if same arguments as last time are passed
+        args = [process_name, window_name, win_x, win_y, win_width, win_height]
+        if self.last_screen_change == args:
+            return
+
+        self.last_screen_change = args
 
         cur_process = self.session.query(
             Process


### PR DESCRIPTION
These changes improve the sniffer (issue #40) and ignore layered windows like "Fonts".

If you have a "Fonts" window open they are always on top titles would be incorrect. Layered windows are moved back in windowList, so if the only window open is a layered window you will see it.