### PR TITLE
Fixed detection of window title in full-screen mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 bin/
 lib/
 include/
+.python-version

--- a/selfspy/models.py
+++ b/selfspy/models.py
@@ -70,7 +70,7 @@ class Window(SpookMixin, Base):
         self.process_id = process_id
 
     def __repr__(self):
-        return "<Window '%s'>" % (self.title)
+        return "<Window '%s'>" % (repr(self.title))
 
 
 class Geometry(SpookMixin, Base):

--- a/selfspy/sniff_cocoa.py
+++ b/selfspy/sniff_cocoa.py
@@ -164,15 +164,15 @@ class Sniffer:
                         options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements
                         windowList = CGWindowListCopyWindowInfo(options,
                                                                 kCGNullWindowID)
-                        windowListLayered = [
+                        windowListLowPrio = [
                             w for w in windowList
-                            if w['kCGWindowLayer']
+                            if w['kCGWindowLayer'] or not w.get('kCGWindowName', u'')
                         ]
                         windowList = [
                             w for w in windowList
-                            if not w['kCGWindowLayer']
+                            if not w['kCGWindowLayer'] and w.get('kCGWindowName', u'')
                         ]
-                        windowList = windowList + windowListLayered
+                        windowList = windowList + windowListLowPrio
                         for window in windowList:
                             if window['kCGWindowOwnerName'] == app_name:
                                 geometry = window['kCGWindowBounds']

--- a/selfspy/sniff_cocoa.py
+++ b/selfspy/sniff_cocoa.py
@@ -40,6 +40,8 @@ import config as cfg
 import signal
 import time
 
+FORCE_SCREEN_CHANGE = 10
+WAIT_ANIMATION = 1
 
 class Sniffer:
     def __init__(self):
@@ -107,7 +109,7 @@ class Sniffer:
             event_type = event.type()
             todo = lambda: None
             if (
-                time.time() - self.last_check_windows > 10 and
+                time.time() - self.last_check_windows > FORCE_SCREEN_CHANGE and
                 event_type != NSKeyUp
             ):
                 self.last_check_windows = time.time()
@@ -154,8 +156,11 @@ class Sniffer:
             elif event_type == NSMouseMoved:
                 todo = lambda: self.mouse_move_hook(loc.x, loc.y)
             elif event_type == NSFlagsChanged:
-                # Register leaving this window on next event
-                self.last_check_windows = 0
+                # Register leaving this window after animations are done
+                # approx (1 second)
+                self.last_check_windows = (time.time() - FORCE_SCREEN_CHANGE +
+                                           WAIT_ANIMATION)
+                check_windows = True
             if check_windows:
                 activeApps = self.workspace.runningApplications()
                 for app in activeApps:


### PR DESCRIPTION
On yosemite full screen windows seem to have some kind of helper window without
title on top. I fixed this by moving windows without title to the low-prio
window-list. I think this fix is valid, because on OSX every visible window has
a title and we don't ignore windows without title, they just have a lower
priority.

Also contains a small fix to wait for desktop changing animations and sample to current window again, without this fast switching between full-screen windows won't work.