### PR TITLE
fix a misdetection of screen_hook caused by localized app names

### DIFF
--- a/selfspy/sniff_cocoa.py
+++ b/selfspy/sniff_cocoa.py
@@ -165,6 +165,7 @@ class Sniffer:
                 activeApps = self.workspace.runningApplications()
                 for app in activeApps:
                     if app.isActive():
+                        app_pid = app.processIdentifier()
                         app_name = app.localizedName()
                         options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements
                         windowList = CGWindowListCopyWindowInfo(options,
@@ -179,9 +180,9 @@ class Sniffer:
                         ]
                         windowList = windowList + windowListLowPrio
                         for window in windowList:
-                            if window['kCGWindowOwnerName'] == app_name:
+                            if window['kCGWindowOwnerPID'] == app_pid:
                                 geometry = window['kCGWindowBounds']
-                                self.screen_hook(window['kCGWindowOwnerName'],
+                                self.screen_hook(app_name,
                                                  window.get('kCGWindowName', u''),
                                                  geometry['X'],
                                                  geometry['Y'],


### PR DESCRIPTION
`sniff_cocoa.py` compares a localized name of running applications with `kCGWindowOwnerName`. However, it causes misdetections when the localized name differs from the application name. For example, `app.localizedName()` returns `ターミナル` for `Terminal.app` in my Japanese environment.

So I suggest comparing `app.processIdentifier()` with `kCGWindowOwnerPID`.
