### PR TITLE
remove Makefile (Closes: #21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-build:
-	@echo "Nothing to build. Only install. Destination is: " $(DESTDIR)
-
-install:
-	mkdir -p $(DESTDIR)/var/lib/selfspy
-	install selfspy/*.py $(DESTDIR)/var/lib/selfspy
-#mkdir -p ~/.selfspy
-	ln -s $(DESTDIR)/var/lib/selfspy/__init__.py $(DESTDIR)/usr/bin/selfspy
-	ln -s $(DESTDIR)/var/lib/selfspy/stats.py $(DESTDIR)/usr/bin/selfstats

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ sudo make config-recursive && sudo make install clean
 ```
 
 
-There is also a simple Makefile. Run `make install` as root/sudo, to install the files in /var/lib/selfspy and also create the symlinks /usr/bin/selfspy and /usr/bin/selfstats.
-
 Report issues here:
 https://github.com/gurgeh/selfspy/issues
 


### PR DESCRIPTION
the makefile doesn't bring any advantage over the normal `python
setup.py install` instructions and just add an extra
dependencies. furthermore, it installs files in a non-standard
location that should generally be avoided.

it will also break Debian packaging, which will think this is a C
program and try to install it as such (and then in the wrong location).