### PR TITLE
recover when lock is stale

### DIFF
--- a/selfspy/__init__.py
+++ b/selfspy/__init__.py
@@ -97,10 +97,14 @@ def main():
     lockname = os.path.join(args['data_dir'], cfg.LOCK_FILE)
     cfg.LOCK = LockFile(lockname)
     if cfg.LOCK.is_locked():
-        print '%s is locked! I am probably already running.' % lockname
-        print 'If you can find no selfspy process running, it is a stale lock and you can safely remove it.'
-        print 'Shutting down.'
-        sys.exit(1)
+        if os.path.exists(lockname):
+            print('%s is locked! I am probably already running.' % lockname)
+            print('If you can find no selfspy process running, it is a stale lock and you can safely remove it.')
+            print('Shutting down.')
+            sys.exit(1)
+        else:
+            print('%s is locked, but no PID file exists. Breaking lock' % lockname)
+            cfg.LOCK.break_lock()
 
     if args['no_text']:
         args['password'] = ""


### PR DESCRIPTION
Whenever selfspy would crash (or even exit), it would leave behind the
lockfile, which is a problem in itself, which this doesn't fix. But at
least, we should be able to recover when a lockfile is left behind but
the actual PID file is missing.